### PR TITLE
Cleanup workflows

### DIFF
--- a/.github/workflows/leecher.yml
+++ b/.github/workflows/leecher.yml
@@ -43,20 +43,4 @@ jobs:
          timeout-minutes: 340
          run: |
            docker run leecher
-           
-       - name: Loop workflow
-         run: |
-              git clone https://github.com/ElytrA8/mirrorbot-workflow loop
-              cd loop
-              echo "1" >> loop.txt
-              git add loop.txt
-              git commit -m "Workflow : Loop"
-              expect -c "
-              spawn git push -f 
-              expect \"Username\"
-              send \"${{ secrets.GHUSER }}\r\"
-              expect \"Password\"
-              send \"${{ secrets.GHPASS }}\r\"
-              expect \"main -> main\"
-              set timeout -10
-              interact"
+ 


### PR DESCRIPTION
How this works : 

by running [push], **both** workflows get triggered with 1 same commit.

For this, one commit can do what both needs to do. If both workflows trigger each other, you'll be stuck in an endless loop and both bots won't work.

